### PR TITLE
Don't show agent viz until participant arrives

### DIFF
--- a/VoiceAssistant/StatusView.swift
+++ b/VoiceAssistant/StatusView.swift
@@ -27,7 +27,12 @@ struct StatusView: View {
     }
 
     var body: some View {
-        AgentBarAudioVisualizer(audioTrack: agentParticipant?.firstAudioTrack, agentState: agentState, barColor: .primary, barCount: 5)
-            .id(agentParticipant?.firstAudioTrack?.id)
+        if let participant = agentParticipant {
+            AgentBarAudioVisualizer(audioTrack: participant.firstAudioTrack, agentState: agentState, barColor: .primary, barCount: 5)
+                .id(participant.firstAudioTrack?.id)
+        } else {
+            // Placeholder for when agent audio isn't available yet, so the app geometry doesn't change
+            Rectangle().fill(.clear)
+        }
     }
 }


### PR DESCRIPTION
The current behavior shows what appears (from user perspective) to be a loading or no signal indicator even when disconnected. This restores the original behavior that the visualizer doesn't appear until the agent does.