### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/livekit-examples/agent-starter-swift/security/code-scanning/6](https://github.com/livekit-examples/agent-starter-swift/security/code-scanning/6)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yaml` so all jobs get least-privilege token scope by default.

Best single fix (minimal and safe):
- Insert after the `on:` trigger block (before `concurrency:`) a root-level:
  - `permissions:`
  - `  contents: read`

This is sufficient for `actions/checkout@v4` and CI read operations in the shown workflow, and avoids granting any write scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
