### PR TITLE
Autoconnect to homepage agent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,9 +40,6 @@ jobs:
       - name: Swift Version
         run: xcrun swift --version
 
-      - name: Setup .env
-        run: cat VoiceAgent/.env.example.xcconfig > VoiceAgent/.env.xcconfig
-
       - name: Build
         run: |
           set -o pipefail && xcodebuild build \

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,4 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 
-.env.xcconfig
-
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If your agent publishes a [virtual avatar](https://docs.livekit.io/agents/integr
 
 ## Token generation in production
 
-In production, you'll need to develop a solution to [generate tokens for your users](https://docs.livekit.io/home/server/generating-tokens/) that integrates with your authentication system. Replace the `SandboxTokenSource` in `AgentToConnect.tokenSource` with an `EndpointTokenSource` (as the homepage agent case does) or your own `TokenSourceFixed` or `TokenSourceConfigurable` implementation. Additionally, you can use the `.cached()` extension to cache valid tokens and avoid unnecessary token requests.
+In production, you'll need to develop a solution to [generate tokens for your users](https://docs.livekit.io/home/server/generating-tokens/) that integrates with your authentication system. Replace the `SandboxTokenSource` in `AgentToConnect.tokenSource` with an `EndpointTokenSource` (as the homepage agent case does) or your own `TokenSourceFixed` or `TokenSourceConfigurable` implementation.
 
 ## Running on Simulator
 

--- a/README.md
+++ b/README.md
@@ -10,21 +10,28 @@ This template is compatible with iOS, iPadOS, macOS, and visionOS and is free fo
 
 ## Getting started
 
+Run the following command to automatically clone this template and connect it to LiveKit Cloud. This will create a new Xcode project in the current directory.
+
+```bash
+lk app create --template agent-starter-swift
+```
+
+Then, build and run the app from Xcode by opening `VoiceAgent.xcodeproj`. You may need to adjust your app signing settings to run the app on your device.
+
+The app is configured to connect to the LiveKit homepage agent by default, which you can also try at [livekit.com](https://www.livekit.com). To connect to your own agent, see below.
+
+> [!NOTE]
+> To set up without the LiveKit CLI, clone the repository via git.
+
+## Connect to your agent
+
 First, you'll need a LiveKit agent to speak with. Try our starter agent for [Python](https://github.com/livekit-examples/agent-starter-python), [Node.js](https://github.com/livekit-examples/agent-starter-node), or [create your own from scratch](https://docs.livekit.io/agents/start/voice-ai/).
 
 Second, you need a token server. The easiest way to set this up is with a [token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/) and the [LiveKit CLI](https://docs.livekit.io/home/cli/cli-setup/).
 
 Enable the token server from your project's **Options** on the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page in LiveKit Cloud and copy the `sandboxId`.
-Then, run the following command to automatically clone this template and connect it to LiveKit Cloud. This will create a new Xcode project in the current directory.
 
-```bash
-lk app create --template agent-starter-swift --sandbox <token_server_sandbox_id>
-```
-
-Then, build and run the app from Xcode by opening `VoiceAgent.xcodeproj`. You may need to adjust your app signing settings to run the app on your device.
-
-> [!NOTE]
-> To set up without the LiveKit CLI, clone the repository and then either create a `VoiceAgent/.env.xcconfig` with a `LIVEKIT_SANDBOX_ID` (from your project's **Options** on the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page), or modify `VoiceAgent/VoiceAgentApp.swift` to replace the `SandboxTokenSource` with a custom token source implementation.
+Then either create a `VoiceAgent/.env.xcconfig` with a `LIVEKIT_SANDBOX_ID` (from your project's **Options** on the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page), and modify `VoiceAgent/VoiceAgentApp.swift` to replace the `TokenSourceEndpoint` with your development token server or custom token source implementation.
 
 ## Feature overview
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This template is compatible with iOS, iPadOS, macOS, and visionOS and is free fo
 
 ## Getting started
 
-Run the following command to automatically clone this template and connect it to LiveKit Cloud. This will create a new Xcode project in the current directory.
+Run the following command to clone this template using the LiveKit CLI. This will create a new Xcode project in the current directory.
 
 ```bash
 lk app create --template agent-starter-swift
@@ -18,14 +18,14 @@ lk app create --template agent-starter-swift
 
 Then, build and run the app from Xcode by opening `VoiceAgent.xcodeproj`. You may need to adjust your app signing settings to run the app on your device.
 
-The app is configured to connect to the LiveKit homepage agent by default, which you can also try at [livekit.com](https://www.livekit.com). That agent takes voice and text input only, so video and screen sharing are hidden until you point the app at your own agent, see below.
+The app is configured to connect to the LiveKit homepage agent by default, which you can also try at [livekit.com](https://www.livekit.com). That agent takes voice and text input only, so video and screen sharing are hidden until you point the app at your own agent (see [Connect to your agent](#connect-to-your-agent)).
 
 > [!NOTE]
 > To set up without the LiveKit CLI, clone the repository via git.
 
 ## Connect to your agent
 
-To switch from the default agent to your own, first, you'll need to create the LiveKit agent to speak with. Try our starter agent for [Python](https://github.com/livekit-examples/agent-starter-python), [Node.js](https://github.com/livekit-examples/agent-starter-node), or [create your own from scratch](https://docs.livekit.io/agents/start/voice-ai/).
+To switch from the default agent to your own, you first need a LiveKit agent to speak with. Try our starter agent for [Python](https://github.com/livekit-examples/agent-starter-python), [Node.js](https://github.com/livekit-examples/agent-starter-node), or [create your own from scratch](https://docs.livekit.io/agents/start/voice-ai/).
 
 Second, you need a token server. For development, the easiest option is the [sandbox token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/): enable it from your project's **Options** on the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page in LiveKit Cloud and copy the `sandboxId`.
 
@@ -35,7 +35,7 @@ Then edit `AgentToConnect.current` in `VoiceAgent/VoiceAgentApp.swift`:
 static let current: Self = .sandbox(id: "your-sandbox-id")
 ```
 
-That single value picks the token source and enables video and screen share input. For any other setup, add a case with your own [token source](#token-generation-in-production).
+That single value picks the token source and determines whether video and screen share input are enabled. For any other setup, add a case with your own [token source](#token-generation-in-production).
 
 ## Feature overview
 
@@ -46,12 +46,12 @@ This starter app supports several features of the agents framework and is easily
 This app supports text, video, and/or voice input according to the needs of your agent. To update the features enabled in the app, edit `VoiceAgent/VoiceAgentApp.swift` and modify the `.environment()` modifiers to enable or disable features:
 
 ```swift
-.environment(\.voiceEnabled, true)   // Enable voice input
-.environment(\.videoEnabled, false)  // Disable video and screen share input
-.environment(\.textEnabled, true)    // Enable text input
+.environment(\.voiceEnabled, true)                                 // Enable voice input
+.environment(\.videoEnabled, AgentToConnect.current.videoEnabled)  // Video and screen share input
+.environment(\.textEnabled, true)                                  // Enable text input
 ```
 
-Voice and text are enabled by default; video follows `AgentToConnect.current`, since the default homepage agent does not accept it.
+Voice and text are enabled by default; video follows `AgentToConnect.current`, since the default homepage agent does not accept it. To override a feature, replace its value with `true` or `false`.
 
 Available input types:
 - `.voice`: Allows the user to speak to the agent using their microphone. **Requires microphone permissions.**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ lk app create --template agent-starter-swift
 
 Then, build and run the app from Xcode by opening `VoiceAgent.xcodeproj`. You may need to adjust your app signing settings to run the app on your device.
 
-The app is configured to connect to the LiveKit homepage agent by default, which you can also try at [livekit.com](https://www.livekit.com). To connect to your own agent, see below.
+The app is configured to connect to the LiveKit homepage agent by default, which you can also try at [livekit.com](https://www.livekit.com). That agent takes voice and text input only, so video and screen sharing are hidden until you point the app at your own agent, see below.
 
 > [!NOTE]
 > To set up without the LiveKit CLI, clone the repository via git.
@@ -27,11 +27,15 @@ The app is configured to connect to the LiveKit homepage agent by default, which
 
 To switch from the default agent to your own, first, you'll need to create the LiveKit agent to speak with. Try our starter agent for [Python](https://github.com/livekit-examples/agent-starter-python), [Node.js](https://github.com/livekit-examples/agent-starter-node), or [create your own from scratch](https://docs.livekit.io/agents/start/voice-ai/).
 
-Second, you need a token server. The easiest way to set this up is with a [token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/) and the [LiveKit CLI](https://docs.livekit.io/home/cli/cli-setup/).
+Second, you need a token server. For development, the easiest option is the [sandbox token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/): enable it from your project's **Options** on the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page in LiveKit Cloud and copy the `sandboxId`.
 
-Enable the token server from your project's **Options** on the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page in LiveKit Cloud and copy the `sandboxId`.
+Then edit `AgentToConnect.current` in `VoiceAgent/VoiceAgentApp.swift`:
 
-Then either create a `VoiceAgent/.env.xcconfig` with a `LIVEKIT_SANDBOX_ID` (from your project's **Options** on the [Settings](https://cloud.livekit.io/projects/p_/settings/project) page), and modify `VoiceAgent/VoiceAgentApp.swift` to replace the `TokenSourceEndpoint` with your development token server or custom token source implementation.
+```swift
+static let current: Self = .sandbox(id: "your-sandbox-id")
+```
+
+That single value picks the token source and enables video and screen share input. For any other setup, add a case with your own [token source](#token-generation-in-production).
 
 ## Feature overview
 
@@ -39,15 +43,15 @@ This starter app supports several features of the agents framework and is easily
 
 ### Text, video, and voice input
 
-This app supports text, video, and/or voice input according to the needs of your agent. To update the features enabled in the app, edit `VoiceAgent/VoiceAgentApp.swift` and modify the `.environment()` modifiers to enable or disable features.
-
-By default, all features (voice, video, and text input) are enabled. To disable a feature, change the value from `true` to `false`:
+This app supports text, video, and/or voice input according to the needs of your agent. To update the features enabled in the app, edit `VoiceAgent/VoiceAgentApp.swift` and modify the `.environment()` modifiers to enable or disable features:
 
 ```swift
 .environment(\.voiceEnabled, true)   // Enable voice input
-.environment(\.videoEnabled, false)  // Disable video input
+.environment(\.videoEnabled, false)  // Disable video and screen share input
 .environment(\.textEnabled, true)    // Enable text input
 ```
+
+Voice and text are enabled by default; video follows `AgentToConnect.current`, since the default homepage agent does not accept it.
 
 Available input types:
 - `.voice`: Allows the user to speak to the agent using their microphone. **Requires microphone permissions.**
@@ -72,7 +76,7 @@ If your agent publishes a [virtual avatar](https://docs.livekit.io/agents/integr
 
 ## Token generation in production
 
-In production, you'll need to develop a solution to [generate tokens for your users](https://docs.livekit.io/home/server/generating-tokens/) that integrates with your authentication system. If used, you should replace your `SandboxTokenSource` with an `EndpointTokenSource` or your own `TokenSourceFixed` or `TokenSourceConfigurable` implementation. Additionally, you can use the `.cached()` extension to cache valid tokens and avoid unnecessary token requests.
+In production, you'll need to develop a solution to [generate tokens for your users](https://docs.livekit.io/home/server/generating-tokens/) that integrates with your authentication system. Replace the `SandboxTokenSource` in `AgentToConnect.tokenSource` with an `EndpointTokenSource` (as the homepage agent case does) or your own `TokenSourceFixed` or `TokenSourceConfigurable` implementation. Additionally, you can use the `.cached()` extension to cache valid tokens and avoid unnecessary token requests.
 
 ## Running on Simulator
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The app is configured to connect to the LiveKit homepage agent by default, which
 
 ## Connect to your agent
 
-First, you'll need a LiveKit agent to speak with. Try our starter agent for [Python](https://github.com/livekit-examples/agent-starter-python), [Node.js](https://github.com/livekit-examples/agent-starter-node), or [create your own from scratch](https://docs.livekit.io/agents/start/voice-ai/).
+To switch from the default agent to your own, first, you'll need to create the LiveKit agent to speak with. Try our starter agent for [Python](https://github.com/livekit-examples/agent-starter-python), [Node.js](https://github.com/livekit-examples/agent-starter-node), or [create your own from scratch](https://docs.livekit.io/agents/start/voice-ai/).
 
 Second, you need a token server. The easiest way to set this up is with a [token server](https://docs.livekit.io/frontends/authentication/tokens/sandbox-token-server/) and the [LiveKit CLI](https://docs.livekit.io/home/cli/cli-setup/).
 
@@ -72,7 +72,7 @@ If your agent publishes a [virtual avatar](https://docs.livekit.io/agents/integr
 
 ## Token generation in production
 
-In production, you'll need to develop a solution to [generate tokens for your users](https://docs.livekit.io/home/server/generating-tokens/) that integrates with your authentication system. You should replace your `SandboxTokenSource` with an `EndpointTokenSource` or your own `TokenSourceFixed` or `TokenSourceConfigurable` implementation. Additionally, you can use the `.cached()` extension to cache valid tokens and avoid unnecessary token requests.
+In production, you'll need to develop a solution to [generate tokens for your users](https://docs.livekit.io/home/server/generating-tokens/) that integrates with your authentication system. If used, you should replace your `SandboxTokenSource` with an `EndpointTokenSource` or your own `TokenSourceFixed` or `TokenSourceConfigurable` implementation. Additionally, you can use the `.cached()` extension to cache valid tokens and avoid unnecessary token requests.
 
 ## Running on Simulator
 

--- a/VoiceAgent.xcodeproj/project.pbxproj
+++ b/VoiceAgent.xcodeproj/project.pbxproj
@@ -55,8 +55,6 @@
 		B577A91F2D15FDB800B59A0B /* Exceptions for "VoiceAgent" folder in "VoiceAgent" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				.env.example.xcconfig,
-				.env.xcconfig,
 				Info.plist,
 				VoiceAgent.xcconfig,
 			);

--- a/VoiceAgent/.env.example.xcconfig
+++ b/VoiceAgent/.env.example.xcconfig
@@ -1,1 +1,0 @@
-LIVEKIT_SANDBOX_ID="<your Sandbox ID>"

--- a/VoiceAgent/App/AppView.swift
+++ b/VoiceAgent/App/AppView.swift
@@ -117,12 +117,19 @@ struct AppView: View {
                !localMedia.isCameraEnabled,
                !localMedia.isScreenShareEnabled
             {
-                Text("agent.listening")
-                    .font(.system(size: 15))
-                    .shimmering()
-                    .transition(.blurReplace)
+                Group {
+                    if session.agent.isConnected {
+                        Text("agent.listening")
+                    } else {
+                        Text("agent.waiting")
+                    }
+                }
+                .font(.system(size: 15))
+                .shimmering()
+                .transition(.blurReplace)
             }
         }
         .animation(.default, value: session.messages.isEmpty)
+        .animation(.default, value: session.agent.isConnected)
     }
 }

--- a/VoiceAgent/Info.plist
+++ b/VoiceAgent/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
-	<key>LiveKitSandboxId</key>
-	<string>$(LIVEKIT_SANDBOX_ID)</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/VoiceAgent/Localizable.xcstrings
+++ b/VoiceAgent/Localizable.xcstrings
@@ -1,13 +1,24 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "agent.waiting" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for agent, start talking"
+          }
+        }
+      }
+    },
     "agent.listening" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Agent is listening, start talking"
+            "value" : "Agent is listening"
           }
         }
       }

--- a/VoiceAgent/VoiceAgent.xcconfig
+++ b/VoiceAgent/VoiceAgent.xcconfig
@@ -1,4 +1,2 @@
-#include ".env.xcconfig"
-
 PRODUCT_BUNDLE_IDENTIFIER=com.livekit.example.VoiceAssistant
 DEVELOPMENT_TEAM = 76TVFCUKK7;

--- a/VoiceAgent/VoiceAgentApp.swift
+++ b/VoiceAgent/VoiceAgentApp.swift
@@ -19,7 +19,9 @@ struct VoiceAgentApp: App {
     ) as? String ?? ""
 
     /// For development, switch back to the sandbox with
-    /// `SandboxTokenSource(id: Self.sandboxID).cached()`.
+    /// `SandboxTokenSource(id: Self.sandboxID).cached()`
+    /// instead of the TokenSourceEndpoint of the LiveKit
+    /// homepage agent.
     private let session = Session(
         tokenSource: TokenSourceEndpoint(url: URL(string: "https://livekit.com/api/homepage-agent/token")!).cached(),
         options: SessionOptions(room: Room(roomOptions: RoomOptions(

--- a/VoiceAgent/VoiceAgentApp.swift
+++ b/VoiceAgent/VoiceAgentApp.swift
@@ -24,9 +24,9 @@ enum AgentToConnect {
     var tokenSource: any TokenSourceConfigurable {
         switch self {
         case .liveKitHomepage:
-            HomepageTokenSource().cached()
+            HomepageTokenSource()
         case let .sandbox(id):
-            SandboxTokenSource(id: id).cached()
+            SandboxTokenSource(id: id)
         }
     }
 

--- a/VoiceAgent/VoiceAgentApp.swift
+++ b/VoiceAgent/VoiceAgentApp.swift
@@ -1,6 +1,13 @@
 import LiveKit
 import SwiftUI
 
+/// Fetches connection details from a custom backend token endpoint.
+/// The `EndpointTokenSource` protocol provides the POST request and
+/// JSON encoding/decoding; only the URL needs to be supplied.
+struct TokenSourceEndpoint: EndpointTokenSource {
+    let url: URL
+}
+
 @main
 struct VoiceAgentApp: App {
     /// To use the LiveKit Cloud sandbox (development only):
@@ -11,10 +18,10 @@ struct VoiceAgentApp: App {
         forInfoDictionaryKey: "LiveKitSandboxId"
     ) as? String ?? ""
 
-    /// For production, replace the `SandboxTokenSource` with an
-    /// `EndpointTokenSource` or your own `TokenSourceConfigurable`.
+    /// For development, switch back to the sandbox with
+    /// `SandboxTokenSource(id: Self.sandboxID).cached()`.
     private let session = Session(
-        tokenSource: SandboxTokenSource(id: Self.sandboxID).cached(),
+        tokenSource: TokenSourceEndpoint(url: URL(string: "https://livekit.com/api/homepage-agent/token")!).cached(),
         options: SessionOptions(room: Room(roomOptions: RoomOptions(
             defaultScreenShareCaptureOptions: ScreenShareCaptureOptions(useBroadcastExtension: true)
         )))

--- a/VoiceAgent/VoiceAgentApp.swift
+++ b/VoiceAgent/VoiceAgentApp.swift
@@ -1,29 +1,48 @@
 import LiveKit
 import SwiftUI
 
-/// Fetches connection details from a custom backend token endpoint.
-/// The `EndpointTokenSource` protocol provides the POST request and
-/// JSON encoding/decoding; only the URL needs to be supplied.
-struct TokenSourceEndpoint: EndpointTokenSource {
-    let url: URL
+/// The agent this app talks to. Edit ``current`` to switch.
+enum AgentToConnect {
+    struct HomepageTokenSource: EndpointTokenSource {
+        let url = URL(string: "https://livekit.com/api/homepage-agent/token")!
+    }
+
+    /// The LiveKit homepage agent you can also try at https://livekit.com.
+    /// Voice and text only: it does not accept video input.
+    case liveKitHomepage
+
+    /// Your own agent, reached through the LiveKit Cloud sandbox token server
+    /// (development only):
+    /// - Enable the token server from your project's Options on the
+    ///   Settings page: https://cloud.livekit.io/projects/p_/settings/project
+    /// - Pass the sandbox ID from that page here.
+    case sandbox(id: String)
+
+    /// Change this to `.sandbox(id: "your-sandbox-id")` to talk to your own agent.
+    static let current: Self = .liveKitHomepage
+
+    var tokenSource: any TokenSourceConfigurable {
+        switch self {
+        case .liveKitHomepage:
+            HomepageTokenSource().cached()
+        case let .sandbox(id):
+            SandboxTokenSource(id: id).cached()
+        }
+    }
+
+    /// Camera and screen share input, which requires a vision-capable agent.
+    var videoEnabled: Bool {
+        switch self {
+        case .liveKitHomepage: false
+        case .sandbox: true
+        }
+    }
 }
 
 @main
 struct VoiceAgentApp: App {
-    /// To use the LiveKit Cloud sandbox (development only):
-    /// - Enable the token server from your project's Options on the
-    ///   Settings page: https://cloud.livekit.io/projects/p_/settings/project
-    /// - Create a .env.xcconfig file with your LIVEKIT_SANDBOX_ID
-    private static let sandboxID = Bundle.main.object(
-        forInfoDictionaryKey: "LiveKitSandboxId"
-    ) as? String ?? ""
-
-    /// For development, switch back to the sandbox with
-    /// `SandboxTokenSource(id: Self.sandboxID).cached()`
-    /// instead of the TokenSourceEndpoint of the LiveKit
-    /// homepage agent.
     private let session = Session(
-        tokenSource: TokenSourceEndpoint(url: URL(string: "https://livekit.com/api/homepage-agent/token")!).cached(),
+        tokenSource: AgentToConnect.current.tokenSource,
         options: SessionOptions(room: Room(roomOptions: RoomOptions(
             defaultScreenShareCaptureOptions: ScreenShareCaptureOptions(useBroadcastExtension: true)
         )))
@@ -35,7 +54,7 @@ struct VoiceAgentApp: App {
                 .environmentObject(session)
                 .environmentObject(LocalMedia(session: session))
                 .environment(\.voiceEnabled, true)
-                .environment(\.videoEnabled, true)
+                .environment(\.videoEnabled, AgentToConnect.current.videoEnabled)
                 .environment(\.textEnabled, true)
         }
         #if os(macOS)

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -1,9 +1,5 @@
 version: "3"
 
-vars:
-  env_file: "VoiceAgent/.env.xcconfig"
-  env_example: "VoiceAgent/.env.example.xcconfig"
-
 tasks:
   post_create:
     desc: "Runs after this template is instantiated as a Sandbox or Bootstrap"


### PR DESCRIPTION
### Background

[Ticket](https://linear.app/livekit/project/agents-samples-to-auto-connect-to-homepage-agent-b69e3d0f501f/overview)

We want to change the agent starter samples to auto-connect to our homepage agent by default to lower the entry barrier for new developers to talk to their first agent.

So now the devs first step is to install the app and talk to our agent, then learn how to deploy your agent and configure the tokens source. 

### Changes

- Set the homepage agent token server as the default token endpoint
- Change documentation to a two step: first try our agent, then configure your own
- Remove the screen share and video share UI when agent connects to the homepage agent
- Split displayed text into before and after agent joins to distinguish agent has not joined yet
- Remove env setup in CI