### PR TITLE
Add audio options panel with voice processing mode picker

### DIFF
--- a/VoiceAgent.xcodeproj/project.pbxproj
+++ b/VoiceAgent.xcodeproj/project.pbxproj
@@ -614,7 +614,7 @@
 			repositoryURL = "https://github.com/livekit/client-sdk-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.15.3;
+				minimumVersion = 2.16.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/VoiceAgent.xcodeproj/project.pbxproj
+++ b/VoiceAgent.xcodeproj/project.pbxproj
@@ -614,7 +614,7 @@
 			repositoryURL = "https://github.com/livekit/client-sdk-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.15.0;
+				minimumVersion = 2.15.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/VoiceAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/livekit/client-sdk-swift",
       "state" : {
-        "revision" : "43ade336353ad12f9ec7fa1e6a51d9b3bd8121f8",
-        "version" : "2.15.3"
+        "revision" : "79fb2beee98e45556bffebefa50b5d05c3382af1",
+        "version" : "2.16.0"
       }
     },
     {

--- a/VoiceAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VoiceAgent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/livekit/client-sdk-swift",
       "state" : {
-        "revision" : "9859018394f1b34e3e04ae859debce96d855e1d8",
-        "version" : "2.15.0"
+        "revision" : "43ade336353ad12f9ec7fa1e6a51d9b3bd8121f8",
+        "version" : "2.15.3"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/livekit/webrtc-xcframework.git",
       "state" : {
-        "revision" : "53d268c89d242791f0771fb022fe4b423f2263d9",
-        "version" : "144.7559.8"
+        "revision" : "46f2af86f06b9a8a9158d37cadda5cb5a214e4c4",
+        "version" : "144.7559.11"
       }
     }
   ],

--- a/VoiceAgent/App/StartView.swift
+++ b/VoiceAgent/App/StartView.swift
@@ -95,7 +95,7 @@ struct StartView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .sheet(isPresented: $audioOptionsPresented) {
+        .popover(isPresented: $audioOptionsPresented) {
             AudioOptionsSheet()
         }
     }

--- a/VoiceAgent/App/StartView.swift
+++ b/VoiceAgent/App/StartView.swift
@@ -8,10 +8,13 @@ struct StartView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Namespace private var button
 
+    @State private var audioOptionsPresented = false
+
     var body: some View {
         VStack(spacing: 8 * .grid) {
             bars()
             connectButton()
+            audioOptionsButton()
         }
         .padding(.horizontal, horizontalSizeClass == .regular ? 32 * .grid : 16 * .grid)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -77,6 +80,24 @@ struct StartView: View {
         #else
         .buttonStyle(ProminentButtonStyle())
         #endif
+    }
+
+    private func audioOptionsButton() -> some View {
+        Button {
+            audioOptionsPresented = true
+        } label: {
+            HStack(spacing: .grid) {
+                Image(systemName: "slider.horizontal.3")
+                Text("audio.title")
+            }
+            .font(.system(size: 13))
+            .foregroundStyle(.fg3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $audioOptionsPresented) {
+            AudioOptionsSheet()
+        }
     }
 }
 

--- a/VoiceAgent/AudioOptions/AudioOptions.swift
+++ b/VoiceAgent/AudioOptions/AudioOptions.swift
@@ -14,7 +14,9 @@ enum VoiceProcessingMode: CaseIterable, Identifiable {
     /// for the microphone.
     case software
 
-    var id: Self { self }
+    var id: Self {
+        self
+    }
 }
 
 /// Stores the selected audio options and applies them to the local microphone.
@@ -42,7 +44,7 @@ final class AudioOptions: ObservableObject {
         cancellable = localMedia.$microphoneTrack
             .map { $0 as? LocalAudioTrack }
             .removeDuplicates { $0 === $1 }
-            .compactMap { $0 }
+            .compactMap(\.self)
             .sink { [weak self] track in
                 guard let self, voiceProcessingMode != .automatic else { return }
                 apply(to: track)

--- a/VoiceAgent/AudioOptions/AudioOptions.swift
+++ b/VoiceAgent/AudioOptions/AudioOptions.swift
@@ -1,0 +1,93 @@
+import Combine
+import LiveKit
+import SwiftUI
+
+/// Selects which implementation handles microphone voice processing
+/// (echo cancellation, noise suppression, and auto gain control).
+enum VoiceProcessingMode: CaseIterable, Identifiable {
+    /// Prefer Apple voice processing when available and fall back to
+    /// WebRTC software processing. This is the SDK default.
+    case automatic
+    /// Use Apple voice processing only. Applying fails when it is not available.
+    case platform
+    /// Use WebRTC software processing. Turns off Apple voice processing
+    /// for the microphone.
+    case software
+
+    var id: Self { self }
+}
+
+/// Stores the selected audio options and applies them to the local microphone.
+///
+/// A selection made before connecting is applied as soon as the microphone
+/// track is created, so it takes effect when the microphone is published.
+/// Changing the selection during a call updates the live track.
+///
+/// To guarantee that the very first captured frames already use custom
+/// processing options, pass them as room defaults instead. See the comment
+/// on `RoomOptions` in `VoiceAgentApp`.
+final class AudioOptions: ObservableObject {
+    @Published var voiceProcessingMode: VoiceProcessingMode = .automatic {
+        didSet {
+            guard oldValue != voiceProcessingMode else { return }
+            applyToMicrophone()
+        }
+    }
+
+    /// The last error from applying the selection, if any.
+    @Published private(set) var applyError: Swift.Error?
+
+    private let localMedia: LocalMedia
+    private var cancellable: AnyCancellable?
+
+    init(localMedia: LocalMedia) {
+        self.localMedia = localMedia
+        // Apply the stored selection whenever a new microphone track appears,
+        // e.g. when pre-connect audio starts capturing.
+        cancellable = localMedia.$microphoneTrack
+            .map { $0 as? LocalAudioTrack }
+            .removeDuplicates { $0 === $1 }
+            .compactMap { $0 }
+            .sink { [weak self] track in
+                guard let self, voiceProcessingMode != .automatic else { return }
+                apply(to: track)
+            }
+    }
+
+    /// The selected mode as SDK processing options.
+    /// All processing components stay enabled, only the implementation changes.
+    var processingOptions: AudioProcessingOptions {
+        switch voiceProcessingMode {
+        case .automatic:
+            AudioProcessingOptions()
+        case .platform:
+            AudioProcessingOptions(
+                echoCancellationMode: .platform,
+                autoGainControlMode: .platform,
+                noiseSuppressionMode: .platform
+            )
+        case .software:
+            AudioProcessingOptions(
+                echoCancellationMode: .software,
+                autoGainControlMode: .software,
+                noiseSuppressionMode: .software
+            )
+        }
+    }
+
+    private func applyToMicrophone() {
+        applyError = nil
+        // Without a track the selection is stored and applied on the next publish
+        guard let track = localMedia.microphoneTrack as? LocalAudioTrack else { return }
+        apply(to: track)
+    }
+
+    private func apply(to track: LocalAudioTrack) {
+        do {
+            try track.setAudioProcessingOptions(processingOptions)
+            applyError = nil
+        } catch {
+            applyError = error
+        }
+    }
+}

--- a/VoiceAgent/AudioOptions/AudioOptions.swift
+++ b/VoiceAgent/AudioOptions/AudioOptions.swift
@@ -27,12 +27,7 @@ enum VoiceProcessingMode: CaseIterable, Identifiable {
 /// processing options, pass them as room defaults instead. See the comment
 /// on `RoomOptions` in `VoiceAgentApp`.
 final class AudioOptions: ObservableObject {
-    @Published var voiceProcessingMode: VoiceProcessingMode = .automatic {
-        didSet {
-            guard oldValue != voiceProcessingMode else { return }
-            applyToMicrophone()
-        }
-    }
+    @Published private(set) var voiceProcessingMode: VoiceProcessingMode = .automatic
 
     /// The last error from applying the selection, if any.
     @Published private(set) var applyError: Swift.Error?
@@ -75,9 +70,11 @@ final class AudioOptions: ObservableObject {
         }
     }
 
-    private func applyToMicrophone() {
+    /// Applies the given mode to the local microphone.
+    /// Without a track the selection is stored and applied on the next publish.
+    func apply(_ mode: VoiceProcessingMode) {
+        voiceProcessingMode = mode
         applyError = nil
-        // Without a track the selection is stored and applied on the next publish
         guard let track = localMedia.microphoneTrack as? LocalAudioTrack else { return }
         apply(to: track)
     }

--- a/VoiceAgent/AudioOptions/AudioOptions.swift
+++ b/VoiceAgent/AudioOptions/AudioOptions.swift
@@ -65,6 +65,10 @@ final class AudioOptions: ObservableObject {
             )
         case .software:
             AudioProcessingOptions(
+                echoCancellation: true,
+                autoGainControl: true,
+                noiseSuppression: true,
+                highpassFilter: false,
                 echoCancellationMode: .software,
                 autoGainControlMode: .software,
                 noiseSuppressionMode: .software

--- a/VoiceAgent/AudioOptions/AudioOptionsSheet.swift
+++ b/VoiceAgent/AudioOptions/AudioOptionsSheet.swift
@@ -1,0 +1,57 @@
+import LiveKit
+import SwiftUI
+
+/// A minimal panel with audio options, shared between the start screen
+/// and the in-call control bar.
+struct AudioOptionsSheet: View {
+    @EnvironmentObject private var audioOptions: AudioOptions
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Picker("audio.mode.title", selection: $audioOptions.voiceProcessingMode) {
+                        Text("audio.mode.automatic").tag(VoiceProcessingMode.automatic)
+                        Text("audio.mode.platform").tag(VoiceProcessingMode.platform)
+                        Text("audio.mode.software").tag(VoiceProcessingMode.software)
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                } header: {
+                    Text("audio.mode.title")
+                } footer: {
+                    VStack(alignment: .leading, spacing: .grid) {
+                        Text(modeDescription)
+                        if let error = audioOptions.applyError {
+                            Text(error.localizedDescription)
+                                .foregroundStyle(.fgSerious)
+                        }
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle("audio.title")
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+            #endif
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("audio.done") { dismiss() }
+                    }
+                }
+        }
+        #if os(macOS)
+        .frame(minWidth: 105 * .grid, minHeight: 45 * .grid)
+        #endif
+        .presentationDetents([.medium])
+    }
+
+    private var modeDescription: LocalizedStringKey {
+        switch audioOptions.voiceProcessingMode {
+        case .automatic: "audio.mode.automatic.description"
+        case .platform: "audio.mode.platform.description"
+        case .software: "audio.mode.software.description"
+        }
+    }
+}

--- a/VoiceAgent/AudioOptions/AudioOptionsSheet.swift
+++ b/VoiceAgent/AudioOptions/AudioOptionsSheet.swift
@@ -4,6 +4,9 @@ import SwiftUI
 /// A minimal panel with audio options, shared between the start screen
 /// and the in-call microphone menu.
 ///
+/// Presented as a popover, which sizes itself to this content. Dismissing
+/// by tapping outside discards the selection, so there is no close button.
+///
 /// The selection takes effect on Apply, not while changing the picker.
 struct AudioOptionsSheet: View {
     @EnvironmentObject private var audioOptions: AudioOptions
@@ -12,47 +15,60 @@ struct AudioOptionsSheet: View {
     @State private var selectedMode: VoiceProcessingMode = .automatic
 
     var body: some View {
-        NavigationStack {
-            Form {
-                Section {
-                    Picker("audio.mode.title", selection: $selectedMode) {
-                        Text("audio.mode.automatic").tag(VoiceProcessingMode.automatic)
-                        Text("audio.mode.platform").tag(VoiceProcessingMode.platform)
-                        Text("audio.mode.software").tag(VoiceProcessingMode.software)
-                    }
-                    .pickerStyle(.segmented)
-                    .labelsHidden()
-                } header: {
-                    Text("audio.mode.title")
-                } footer: {
-                    VStack(alignment: .leading, spacing: .grid) {
-                        Text(modeDescription)
-                        if let error = audioOptions.applyError {
-                            Text(error.localizedDescription)
-                                .foregroundStyle(.fgSerious)
-                        }
-                    }
-                }
+        VStack(alignment: .leading, spacing: 2 * .grid) {
+            Text("audio.mode.title")
+                .font(.subheadline)
+                .foregroundStyle(.fg3)
+
+            Picker("audio.mode.title", selection: $selectedMode) {
+                Text("audio.mode.automatic").tag(VoiceProcessingMode.automatic)
+                Text("audio.mode.platform").tag(VoiceProcessingMode.platform)
+                Text("audio.mode.software").tag(VoiceProcessingMode.software)
             }
-            .formStyle(.grouped)
-            .navigationTitle("audio.title")
-            #if os(iOS)
-                .navigationBarTitleDisplayMode(.inline)
-            #endif
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("audio.close") { dismiss() }
-                    }
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button("audio.apply") { audioOptions.apply(selectedMode) }
-                    }
-                }
-                .onAppear { selectedMode = audioOptions.voiceProcessingMode }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            Text(modeDescription)
+                .font(.footnote)
+                .foregroundStyle(.fg3)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let error = audioOptions.applyError {
+                Text(error.localizedDescription)
+                    .font(.footnote)
+                    .foregroundStyle(.fgSerious)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            applyButton()
+                .padding(.top, 2 * .grid)
         }
-        #if os(macOS)
-        .frame(minWidth: 105 * .grid, minHeight: 45 * .grid)
+        .padding(4 * .grid)
+        // A fixed width keeps the description wrapping predictable, since a
+        // popover otherwise sizes itself around the widest line.
+        .frame(width: 70 * .grid)
+        .presentationCompactAdaptation(.popover)
+        .onAppear { selectedMode = audioOptions.voiceProcessingMode }
+    }
+
+    /// Styled as the primary action, matching the start screen button.
+    private func applyButton() -> some View {
+        Button {
+            audioOptions.apply(selectedMode)
+            dismiss()
+        } label: {
+            HStack {
+                Spacer()
+                Text("audio.apply")
+                Spacer()
+            }
+            .frame(height: 11 * .grid)
+        }
+        #if os(visionOS)
+        .buttonStyle(.borderedProminent)
+        #else
+        .buttonStyle(ProminentButtonStyle())
         #endif
-        .presentationDetents([.medium])
     }
 
     private var modeDescription: LocalizedStringKey {

--- a/VoiceAgent/AudioOptions/AudioOptionsSheet.swift
+++ b/VoiceAgent/AudioOptions/AudioOptionsSheet.swift
@@ -2,16 +2,20 @@ import LiveKit
 import SwiftUI
 
 /// A minimal panel with audio options, shared between the start screen
-/// and the in-call control bar.
+/// and the in-call microphone menu.
+///
+/// The selection takes effect on Apply, not while changing the picker.
 struct AudioOptionsSheet: View {
     @EnvironmentObject private var audioOptions: AudioOptions
     @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedMode: VoiceProcessingMode = .automatic
 
     var body: some View {
         NavigationStack {
             Form {
                 Section {
-                    Picker("audio.mode.title", selection: $audioOptions.voiceProcessingMode) {
+                    Picker("audio.mode.title", selection: $selectedMode) {
                         Text("audio.mode.automatic").tag(VoiceProcessingMode.automatic)
                         Text("audio.mode.platform").tag(VoiceProcessingMode.platform)
                         Text("audio.mode.software").tag(VoiceProcessingMode.software)
@@ -36,10 +40,14 @@ struct AudioOptionsSheet: View {
                 .navigationBarTitleDisplayMode(.inline)
             #endif
                 .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("audio.close") { dismiss() }
+                    }
                     ToolbarItem(placement: .confirmationAction) {
-                        Button("audio.done") { dismiss() }
+                        Button("audio.apply") { audioOptions.apply(selectedMode) }
                     }
                 }
+                .onAppear { selectedMode = audioOptions.voiceProcessingMode }
         }
         #if os(macOS)
         .frame(minWidth: 105 * .grid, minHeight: 45 * .grid)
@@ -48,7 +56,7 @@ struct AudioOptionsSheet: View {
     }
 
     private var modeDescription: LocalizedStringKey {
-        switch audioOptions.voiceProcessingMode {
+        switch selectedMode {
         case .automatic: "audio.mode.automatic.description"
         case .platform: "audio.mode.platform.description"
         case .software: "audio.mode.software.description"

--- a/VoiceAgent/ControlBar/AudioDeviceSelector.swift
+++ b/VoiceAgent/ControlBar/AudioDeviceSelector.swift
@@ -6,6 +6,8 @@ import SwiftUI
     struct AudioDeviceSelector: View {
         @EnvironmentObject private var localMedia: LocalMedia
 
+        @State private var audioOptionsPresented = false
+
         var body: some View {
             Menu {
                 ForEach(localMedia.audioDevices, id: \.deviceId) { device in
@@ -20,11 +22,16 @@ import SwiftUI
                         }
                     }
                 }
+                Divider()
+                Button("audio.title") { audioOptionsPresented = true }
             } label: {
                 Image(systemName: "chevron.down")
                     .frame(height: 11 * .grid)
                     .font(.system(size: 12, weight: .semibold))
                     .contentShape(Rectangle())
+            }
+            .sheet(isPresented: $audioOptionsPresented) {
+                AudioOptionsSheet()
             }
         }
     }

--- a/VoiceAgent/ControlBar/AudioDeviceSelector.swift
+++ b/VoiceAgent/ControlBar/AudioDeviceSelector.swift
@@ -30,7 +30,7 @@ import SwiftUI
                     .font(.system(size: 12, weight: .semibold))
                     .contentShape(Rectangle())
             }
-            .sheet(isPresented: $audioOptionsPresented) {
+            .popover(isPresented: $audioOptionsPresented) {
                 AudioOptionsSheet()
             }
         }

--- a/VoiceAgent/ControlBar/ControlBar.swift
+++ b/VoiceAgent/ControlBar/ControlBar.swift
@@ -125,7 +125,7 @@ struct ControlBar: View {
             Spacer()
         }
         .frame(width: Constants.buttonWidth)
-        .sheet(isPresented: $audioOptionsPresented) {
+        .popover(isPresented: $audioOptionsPresented) {
             AudioOptionsSheet()
         }
     }

--- a/VoiceAgent/ControlBar/ControlBar.swift
+++ b/VoiceAgent/ControlBar/ControlBar.swift
@@ -26,8 +26,6 @@ struct ControlBar: View {
             if voiceEnabled {
                 audioControls()
                 flexibleSpacer()
-                audioOptionsButton()
-                flexibleSpacer()
             }
             if videoEnabled {
                 videoControls()
@@ -103,6 +101,9 @@ struct ControlBar: View {
                 .padding(.horizontal, 2 * .grid)
                 .contentShape(Rectangle())
             }
+            .contextMenu {
+                Button("audio.title") { audioOptionsPresented = true }
+            }
             #if os(macOS)
                 separator()
                 AudioDeviceSelector()
@@ -111,16 +112,6 @@ struct ControlBar: View {
             Spacer()
         }
         .frame(width: Constants.buttonWidth)
-    }
-
-    private func audioOptionsButton() -> some View {
-        Button {
-            audioOptionsPresented = true
-        } label: {
-            Image(systemName: "slider.horizontal.3")
-                .frame(width: Constants.buttonWidth, height: Constants.buttonHeight)
-                .contentShape(Rectangle())
-        }
         .sheet(isPresented: $audioOptionsPresented) {
             AudioOptionsSheet()
         }

--- a/VoiceAgent/ControlBar/ControlBar.swift
+++ b/VoiceAgent/ControlBar/ControlBar.swift
@@ -108,6 +108,19 @@ struct ControlBar: View {
                 separator()
                 AudioDeviceSelector()
                     .frame(height: Constants.buttonHeight)
+            #else
+                // The context menu above is not discoverable on touch platforms,
+                // show an explicit affordance for the audio options.
+                separator()
+                Button {
+                    audioOptionsPresented = true
+                } label: {
+                    Image(systemName: "chevron.up")
+                        .font(.system(size: 12, weight: .semibold))
+                        .frame(height: Constants.buttonHeight)
+                        .padding(.horizontal, .grid)
+                        .contentShape(Rectangle())
+                }
             #endif
             Spacer()
         }

--- a/VoiceAgent/ControlBar/ControlBar.swift
+++ b/VoiceAgent/ControlBar/ControlBar.swift
@@ -13,6 +13,8 @@ struct ControlBar: View {
     @Environment(\.videoEnabled) private var videoEnabled
     @Environment(\.textEnabled) private var textEnabled
 
+    @State private var audioOptionsPresented = false
+
     private enum Constants {
         static let buttonWidth: CGFloat = 16 * .grid
         static let buttonHeight: CGFloat = 11 * .grid
@@ -23,6 +25,8 @@ struct ControlBar: View {
             biggerSpacer()
             if voiceEnabled {
                 audioControls()
+                flexibleSpacer()
+                audioOptionsButton()
                 flexibleSpacer()
             }
             if videoEnabled {
@@ -107,6 +111,19 @@ struct ControlBar: View {
             Spacer()
         }
         .frame(width: Constants.buttonWidth)
+    }
+
+    private func audioOptionsButton() -> some View {
+        Button {
+            audioOptionsPresented = true
+        } label: {
+            Image(systemName: "slider.horizontal.3")
+                .frame(width: Constants.buttonWidth, height: Constants.buttonHeight)
+                .contentShape(Rectangle())
+        }
+        .sheet(isPresented: $audioOptionsPresented) {
+            AudioOptionsSheet()
+        }
     }
 
     private func videoControls() -> some View {

--- a/VoiceAgent/Localizable.xcstrings
+++ b/VoiceAgent/Localizable.xcstrings
@@ -23,6 +23,105 @@
         }
       }
     },
+    "audio.done" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        }
+      }
+    },
+    "audio.mode.automatic" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatic"
+          }
+        }
+      }
+    },
+    "audio.mode.automatic.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prefers Apple voice processing when available and falls back to WebRTC software processing."
+          }
+        }
+      }
+    },
+    "audio.mode.platform" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Platform"
+          }
+        }
+      }
+    },
+    "audio.mode.platform.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uses Apple voice processing only. Applying fails when it is not available."
+          }
+        }
+      }
+    },
+    "audio.mode.software" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Software"
+          }
+        }
+      }
+    },
+    "audio.mode.software.description" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uses WebRTC software processing. Turns off Apple voice processing for the microphone."
+          }
+        }
+      }
+    },
+    "audio.mode.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voice Processing"
+          }
+        }
+      }
+    },
+    "audio.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Audio Options"
+          }
+        }
+      }
+    },
     "connect.connecting" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/VoiceAgent/Localizable.xcstrings
+++ b/VoiceAgent/Localizable.xcstrings
@@ -23,13 +23,24 @@
         }
       }
     },
-    "audio.done" : {
+    "audio.apply" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Done"
+            "value" : "Apply"
+          }
+        }
+      }
+    },
+    "audio.close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         }
       }

--- a/VoiceAgent/VoiceAgentApp.swift
+++ b/VoiceAgent/VoiceAgentApp.swift
@@ -41,18 +41,32 @@ enum AgentToConnect {
 
 @main
 struct VoiceAgentApp: App {
-    private let session = Session(
-        tokenSource: AgentToConnect.current.tokenSource,
-        options: SessionOptions(room: Room(roomOptions: RoomOptions(
-            defaultScreenShareCaptureOptions: ScreenShareCaptureOptions(useBroadcastExtension: true)
-        )))
-    )
+    private let session: Session
+    private let localMedia: LocalMedia
+    private let audioOptions: AudioOptions
+
+    init() {
+        // The audio options panel applies its selection when the microphone
+        // track is created. To guarantee that the very first captured frames
+        // already use custom processing options, set them as room defaults
+        // here instead, e.g.
+        // RoomOptions(defaultAudioCaptureOptions: AudioCaptureOptions(echoCancellationMode: .software, ...))
+        session = Session(
+            tokenSource: AgentToConnect.current.tokenSource,
+            options: SessionOptions(room: Room(roomOptions: RoomOptions(
+                defaultScreenShareCaptureOptions: ScreenShareCaptureOptions(useBroadcastExtension: true)
+            )))
+        )
+        localMedia = LocalMedia(session: session)
+        audioOptions = AudioOptions(localMedia: localMedia)
+    }
 
     var body: some Scene {
         WindowGroup {
             AppView()
                 .environmentObject(session)
-                .environmentObject(LocalMedia(session: session))
+                .environmentObject(localMedia)
+                .environmentObject(audioOptions)
                 .environment(\.voiceEnabled, true)
                 .environment(\.videoEnabled, AgentToConnect.current.videoEnabled)
                 .environment(\.textEnabled, true)


### PR DESCRIPTION
Adds a minimal audio options panel for testing the voice processing implementation modes added in SDK 2.15 (livekit/client-sdk-swift#1048).

The panel is a shared popover with a single Voice Processing picker (Automatic / Platform / Software) and an Apply button. A description under the picker explains the highlighted mode and surfaces apply errors, for example when Platform mode is unavailable. Dismissing by tapping outside discards the selection.

Entry points:

- Connect screen: a small button under Start call
- In call on iOS and visionOS: a chevron next to the mic button, long press on the mic button also works
- In call on macOS: an item in the mic device dropdown, right click on the mic button also works

A selection made before connecting is stored and applied as soon as the microphone track is created, so it takes effect when pre-connect audio starts capturing. Applying during a call updates the live track through `setAudioProcessingOptions`.

Comments in `AudioOptions.swift` and `VoiceAgentApp.swift` explain the modes and point to `RoomOptions.defaultAudioCaptureOptions` for guaranteeing that the very first captured frames use custom options.

Also bumps the SDK to 2.16.0.
